### PR TITLE
Add compat for Simple Kelpies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,10 +106,18 @@ mixin {
     config 'shinyhorses.mixins.json'
 }
 
+repositories {
+    maven {
+        url "https://cursemaven.com"
+    }
+}
+
 dependencies {
     minecraft 'net.minecraftforge:forge:1.20.1-47.1.0'
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+
+    compileOnly fg.deobf("curse.maven:simplekelpies-857856:4904746")
 }
 
 jar {

--- a/src/main/java/com/kuraion/shinyhorses/ShinyHorsesMod.java
+++ b/src/main/java/com/kuraion/shinyhorses/ShinyHorsesMod.java
@@ -1,5 +1,6 @@
 package com.kuraion.shinyhorses;
 
+import com.kuraion.shinyhorses.compat.SimpleKelpiesCompat;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.blaze3d.vertex.VertexMultiConsumer;
@@ -11,6 +12,7 @@ import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.item.HorseArmorItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
@@ -41,6 +43,9 @@ public class ShinyHorsesMod {
 				int level = ((HorseArmorItem) armor.getItem()).getEnchantmentLevel(armor, enchantmentIn);
 				cir.setReturnValue(level);
 			}
+		}
+		if (ModList.get().isLoaded("simplekelpies")){
+			SimpleKelpiesCompat.checkKelpieHook(enchantmentIn, entityIn, cir);
 		}
 	}
 }

--- a/src/main/java/com/kuraion/shinyhorses/compat/ShinyHorsesMixinPlugin.java
+++ b/src/main/java/com/kuraion/shinyhorses/compat/ShinyHorsesMixinPlugin.java
@@ -37,7 +37,7 @@ public class ShinyHorsesMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public List<String> getMixins() {
-        return null;
+        return List.of();
     }
 
     @Override

--- a/src/main/java/com/kuraion/shinyhorses/compat/ShinyHorsesMixinPlugin.java
+++ b/src/main/java/com/kuraion/shinyhorses/compat/ShinyHorsesMixinPlugin.java
@@ -1,0 +1,52 @@
+package com.kuraion.shinyhorses.compat;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraftforge.fml.loading.LoadingModList;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class ShinyHorsesMixinPlugin implements IMixinConfigPlugin {
+    private static final Map<String, Supplier<Boolean>> CONDITIONS = ImmutableMap.of(
+        "com.kuraion.shinyhorses.mixin.KelpieArmorLayerMixin", () -> LoadingModList.get().getModFileById("simplekelpies") != null
+    );
+    @Override
+    public boolean shouldApplyMixin(String target, String mixinToApply) {
+        return CONDITIONS.getOrDefault(mixinToApply, () -> true).get();
+    }
+
+    @Override
+    public void onLoad(String s) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> set, Set<String> set1) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+}

--- a/src/main/java/com/kuraion/shinyhorses/compat/SimpleKelpiesCompat.java
+++ b/src/main/java/com/kuraion/shinyhorses/compat/SimpleKelpiesCompat.java
@@ -1,0 +1,40 @@
+package com.kuraion.shinyhorses.compat;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.blaze3d.vertex.VertexMultiConsumer;
+import net.altias.simplekelpies.entity.custom.KelpieEntity;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.HorseArmorItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+public class SimpleKelpiesCompat {
+    public static void checkKelpieHook(Enchantment enchantmentIn, LivingEntity entityIn, CallbackInfoReturnable<Integer> cir) {
+        if (entityIn instanceof KelpieEntity) {
+            ItemStack armor = ((KelpieEntity) entityIn).getArmor();
+            if (armor.getItem() instanceof HorseArmorItem) {
+                int level = ((HorseArmorItem) armor.getItem()).getEnchantmentLevel(armor, enchantmentIn);
+                cir.setReturnValue(level);
+            }
+        }
+    }
+
+    public static VertexConsumer renderKelpieArmorGlintHook(VertexConsumer old, PoseStack matrixStackIn, MultiBufferSource bufferIn, int packedLightIn, KelpieEntity kelpie, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
+        ItemStack stack = kelpie.getArmor();
+        HorseArmorItem horseArmorItem = (HorseArmorItem) stack.getItem();
+        boolean glint = horseArmorItem.isFoil(stack);
+        if (glint) {
+            ResourceLocation texture = horseArmorItem.getTexture();
+            return VertexMultiConsumer.create(
+                    bufferIn.getBuffer(RenderType.entityGlint()),
+                    bufferIn.getBuffer(RenderType.entityCutoutNoCull(texture))
+            );
+        }
+        return old;
+    }
+}

--- a/src/main/java/com/kuraion/shinyhorses/mixin/KelpieArmorLayerMixin.java
+++ b/src/main/java/com/kuraion/shinyhorses/mixin/KelpieArmorLayerMixin.java
@@ -1,0 +1,21 @@
+package com.kuraion.shinyhorses.mixin;
+
+import com.kuraion.shinyhorses.compat.SimpleKelpiesCompat;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.altias.simplekelpies.entity.client.KelpieArmorLayer;
+import net.altias.simplekelpies.entity.custom.KelpieEntity;
+import net.minecraft.client.renderer.MultiBufferSource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(KelpieArmorLayer.class)
+public class KelpieArmorLayerMixin {
+
+    @ModifyVariable(method = "render*",at = @At(value = "INVOKE_ASSIGN",target = "Lnet/minecraft/client/renderer/MultiBufferSource;getBuffer(Lnet/minecraft/client/renderer/RenderType;)Lcom/mojang/blaze3d/vertex/VertexConsumer;"))
+    private VertexConsumer renderHorseArmorGlint(VertexConsumer old, PoseStack matrixStackIn, MultiBufferSource bufferIn, int packedLightIn, KelpieEntity entitylivingbaseIn,
+                                                 float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
+        return SimpleKelpiesCompat.renderKelpieArmorGlintHook(old, matrixStackIn, bufferIn, packedLightIn, entitylivingbaseIn, limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch);
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -19,6 +19,13 @@ description='''Enchant horse armor and gallop over the freezing ocean!'''
     ordering="NONE"
     side="BOTH"
 
+[[dependencies.shinyhorses]]
+    modId="simplekelpies"
+    mandatory=false
+    versionRange="[1.1.2,)"
+    ordering="NONE"
+    side="BOTH"
+
 
 
 

--- a/src/main/resources/shinyhorses.mixins.json
+++ b/src/main/resources/shinyhorses.mixins.json
@@ -3,13 +3,15 @@
   "package": "com.kuraion.shinyhorses.mixin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "shinyhorses.mixins.refmap.json",
+  "plugin": "com.kuraion.shinyhorses.compat.ShinyHorsesMixinPlugin",
   "mixins": [
     "EnchantmentHelperMixin",
     "EnchantmentCategoryMixin",
     "ItemMixin"
   ],
   "client": [
-    "HorseArmorLayerMixin"
+    "HorseArmorLayerMixin",
+    "KelpieArmorLayerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This adds support for the [Simple Kelpies](https://modrinth.com/mod/simple-kelpies) mod, which adds a mob (the kelpie) that also uses horse armor.

**Summary of changes/additions**
- The compat code is a near duplicate of the existing code, just for the appropriate Simple Kelpies classes. It might be warranted to de-duplicate this, as the code is identical after retrieving the horse armor item from the entity. This has been added to a separate class, so that we don't attempt to load Simple Kelpies classes when it's not installed. 
- Added a basic mixin plugin, as the rendering compat had to be added as another mixin.

**Testing and other concerns**
- I've tested this PR both on server & client, with and without Simple Kelpies installed.
- The jar used as dependency corresponds to version 1.2.1, but this PR also works with the first 1.20.1 release of 1.1.2, so that's the minimum version in mods.toml.
- ~~We mixin into KelpieArmorLayer to render the armor glint, but that class is not pushed to the SimpleKelpies repository and I only learned of its existence in the IDE.~~ (this is probably because the class contains vanilla code and not something nefarious)
- If you still maintain the older versions of this mod, ports to 1.19.2 and 1.19.4 (which Simple Kelpies is also available for) should be trivial enough.
- Second commit resolves an issue that only showed up during gradlew build, used runServer/runClient before